### PR TITLE
Add time windows to longitudinal queries; Fix default args params

### DIFF
--- a/config_web/genomics.py
+++ b/config_web/genomics.py
@@ -9,8 +9,12 @@ APP_LIST_V2 = [
         r"/{pre}/{ver}/lineage-mutations",
         "web.handlers.v2.genomics.lineage_mutations.LineageMutationsHandler",
     ),
-    (r"/{pre}/{ver}/lineage", "web.handlers.v2.genomics.lineage.LineageHandler"),
-    (r"/{pre}/{ver}/location", "web.handlers.v2.genomics.location.LocationHandler"),
+    (r"/{pre}/{ver}/lineage", "web.handlers.v2.genomics.LineageHandler"),
+    (r"/{pre}/{ver}/location", "web.handlers.v2.genomics.LocationHandler"),
+    (
+        r"/{pre}/{ver}/prevalence-by-location",
+        "web.handlers.v2.genomics.PrevalenceByLocationAndTimeHandler",
+    ),
 ]
 
 APP_LIST = [

--- a/web/handlers/genomics/base.py
+++ b/web/handlers/genomics/base.py
@@ -42,8 +42,8 @@ class BaseHandler(BaseAPIHandler):
         pass
 
     async def get(self):
-        if not self.biothings.config.DISABLE_GENOMICS_ENDPOINT:
-            self._get_with_gisauth()
+        if not getattr(self.biothings.config, "DISABLE_GENOMICS_ENDPOINT", False):
+            await self._get_with_gisauth()
         else:
             resp = await self._get()
             self.write(resp)

--- a/web/handlers/genomics/util.py
+++ b/web/handlers/genomics/util.py
@@ -278,3 +278,11 @@ def create_iterator(lineages, mutations):
 
 def get_total_hits(d): # To account for difference in ES versions 7.12.0 vs 6.8.13
     return d["hits"]["total"]["value"] if isinstance(d["hits"]["total"], dict) else d["hits"]["total"]
+
+
+def validate_iso_date(date_str):
+    try:
+        dt.strptime(date_str, '%Y-%m-%d')
+        return True
+    except ValueError:
+        return False

--- a/web/handlers/v2/genomics/__init__.py
+++ b/web/handlers/v2/genomics/__init__.py
@@ -1,0 +1,5 @@
+# flake8: noqa
+from .lineage import LineageHandler
+from .lineage_mutations import LineageMutationsHandler
+from .location import LocationHandler
+from .prevalence_by_location_and_time import PrevalenceByLocationAndTimeHandler

--- a/web/handlers/v2/genomics/lineage.py
+++ b/web/handlers/v2/genomics/lineage.py
@@ -2,6 +2,13 @@ from web.handlers.genomics.base import BaseHandler
 
 
 class LineageHandler(BaseHandler):
+
+    kwargs = dict(BaseHandler.kwargs)
+    kwargs["GET"] = {
+        "name": {"type": str, "default": None},
+        "size": {"type": int, "default": None},
+    }
+
     async def _get(self):
         query_str = self.get_argument("name", None)
         size = self.get_argument("size", None)

--- a/web/handlers/v2/genomics/lineage_mutations.py
+++ b/web/handlers/v2/genomics/lineage_mutations.py
@@ -25,9 +25,9 @@ class LineageMutationsHandler(BaseHandler):
     name = "lineagemutations"
     kwargs = dict(BaseHandler.kwargs)
     kwargs["GET"] = {
-        "pangolin_lineage": {"type": str, "default": ""},
+        "pangolin_lineage": {"type": str, "default": None},
         "frequency": {"type": float, "default": None},
-        "gene": {"type": str, "default": ""},
+        "gene": {"type": str, "default": None},
     }
 
     async def _get(self):

--- a/web/handlers/v2/genomics/location.py
+++ b/web/handlers/v2/genomics/location.py
@@ -258,10 +258,15 @@ class LocationHandler(BaseHandler):
     }
 
     location_types = ["country", "division", "location"]
+    kwargs = dict(BaseHandler.kwargs)
+    kwargs["GET"] = {
+        "name": {"type": str, "default": None},
+        "size": {"type": int, "default": None},
+    }
 
     async def _get(self):
-        query_str = self.get_argument("name", None)
-        size = self.get_argument("size", None)
+        query_str = self.args.name
+        size = self.args.size
         flattened_response = []
         for loc in self.location_types:
             query = {

--- a/web/handlers/v2/genomics/prevalence_by_location_and_time.py
+++ b/web/handlers/v2/genomics/prevalence_by_location_and_time.py
@@ -45,7 +45,7 @@ class PrevalenceByLocationAndTimeHandler(BaseHandler):
         results = {}
         for i, j in create_iterator(query_pangolin_lineage, query_mutations):
             query = {
-                "size": 10,
+                "size": 0,
                 "aggs": {
                     "prevalence": {
                         "filter": {"bool": {"must": []}},

--- a/web/handlers/v2/genomics/prevalence_by_location_and_time.py
+++ b/web/handlers/v2/genomics/prevalence_by_location_and_time.py
@@ -1,0 +1,84 @@
+from tornado.web import HTTPError
+
+from web.handlers.genomics.base import BaseHandler
+from web.handlers.genomics.util import (
+    create_iterator,
+    create_nested_mutation_query,
+    parse_location_id_to_query,
+    transform_prevalence,
+    validate_iso_date,
+)
+
+
+class PrevalenceByLocationAndTimeHandler(BaseHandler):
+    name = "prevalence-by-location"
+    kwargs = dict(BaseHandler.kwargs)
+    kwargs["GET"] = {
+        "pangolin_lineage": {"type": str, "default": None},
+        "mutations": {"type": str, "default": None},
+        "location_id": {"type": str, "default": None},
+        "cumulative": {"type": str, "default": None},
+        "min_date": {"type": str, "default": None},
+        "max_date": {"type": str, "default": None},
+    }
+
+    async def _get(self):
+        query_location = self.args.location_id
+        query_pangolin_lineage = self.args.pangolin_lineage
+        query_pangolin_lineage = (
+            query_pangolin_lineage.split(",") if query_pangolin_lineage is not None else []
+        )
+        query_mutations = self.args.mutations
+        query_mutations = query_mutations.split(" AND ") if query_mutations is not None else []
+        cumulative = self.args.cumulative
+        cumulative = True if cumulative == "true" else False
+        date_range_filter = {"query": {"range": {"date_collected": {}}}}
+        if self.args.max_date:
+            if not validate_iso_date(self.args.max_date):
+                raise HTTPError(400, reason="Invalid max_date format")
+            date_range_filter["query"]["range"]["date_collected"]["lte"] = self.args.max_date
+        if self.args.min_date:
+            if not validate_iso_date(self.args.min_date):
+                raise HTTPError(400, reason="Invalid min_date format")
+            date_range_filter["query"]["range"]["date_collected"]["gte"] = self.args.min_date
+
+        results = {}
+        for i, j in create_iterator(query_pangolin_lineage, query_mutations):
+            query = {
+                "size": 10,
+                "aggs": {
+                    "prevalence": {
+                        "filter": {"bool": {"must": []}},
+                        "aggs": {
+                            "count": {
+                                "terms": {"field": "date_collected", "size": self.size},
+                                "aggs": {"lineage_count": {"filter": {}}},
+                            }
+                        },
+                    }
+                },
+            }
+            if self.args.max_date or self.args.min_date:
+                query.update(date_range_filter)
+            parse_location_id_to_query(query_location, query["aggs"]["prevalence"]["filter"])
+            lineages = i.split(" OR ") if i is not None else []
+            query_obj = create_nested_mutation_query(
+                lineages=lineages, mutations=j, location_id=query_location
+            )
+            query["aggs"]["prevalence"]["aggs"]["count"]["aggs"]["lineage_count"]["filter"] = query_obj
+            # import json
+            # print(json.dumps(query))
+            resp = await self.asynchronous_fetch(query)
+            path_to_results = ["aggregations", "prevalence", "count", "buckets"]
+            resp = transform_prevalence(resp, path_to_results, cumulative)
+            res_key = None
+            if len(query_pangolin_lineage) > 0:
+                res_key = " OR ".join(lineages)
+            if len(query_mutations) > 0:
+                res_key = (
+                    "({}) AND ({})".format(res_key, " AND ".join(query_mutations))
+                    if res_key is not None
+                    else " AND ".join(query_mutations)
+                )
+            results[res_key] = resp
+        return {"success": True, "results": results}


### PR DESCRIPTION
- ref: https://github.com/outbreak-info/outbreak.api/issues/54
- Query params: min_date, max_date
- Example: http://localhost:8001/genomics/v2/prevalence-by-location?pangolin_lineage=BA.1.1&min_date=2022-02-01&max_date=2022-10-01